### PR TITLE
Add bench mark of yu_fold_poly and fold_poly_with_dft

### DIFF
--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -35,3 +35,11 @@ rand_chacha = "0.3.1"
 [[bench]]
 name = "fold_even_odd"
 harness = false
+
+[[bench]]
+name = "yu_fold_poly"
+harness = false
+
+[[bench]]
+name = "fold_poly_with_dft"
+harness = false

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -6,6 +6,8 @@ use p3_baby_bear::BabyBear;
 use p3_field::extension::Complex;
 use p3_field::TwoAdicField;
 use p3_fri::fold_even_odd;
+use p3_fri::yu_fold_poly;
+use p3_fri::fold_poly_with_dft;
 use p3_goldilocks::Goldilocks;
 use p3_mersenne_31::Mersenne31;
 use rand::distributions::{Distribution, Standard};
@@ -34,6 +36,57 @@ where
     }
 }
 
+fn bench_yu<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
+where
+    Standard: Distribution<F>,
+{
+    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+
+    for log_size in log_sizes {
+        for folding_factor in folding_factors{
+            let n = 1 << log_size;
+
+            let mut rng = thread_rng();
+            let beta = rng.sample(Standard);
+            let poly = rng.sample_iter(Standard).take(n).collect_vec();
+    
+            group.bench_function(BenchmarkId::from_parameter(n), |b| {
+                b.iter(|| {
+                    yu_fold_poly(poly.clone(), beta, *folding_factor);
+                })
+            });
+        }
+    }
+}
+
+
+fn bench_dft<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
+where
+    Standard: Distribution<F>,
+{
+    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+
+    for log_size in log_sizes {
+        for folding_factor in folding_factors{
+            let n = 1 << log_size;
+
+            let mut rng = thread_rng();
+            let beta = rng.sample(Standard);
+            let poly = rng.sample_iter(Standard).take(n).collect_vec();
+    
+            group.bench_function(BenchmarkId::from_parameter(n), |b| {
+                b.iter(|| {
+                    fold_poly_with_dft(poly.clone(), beta, *folding_factor);
+                })
+            });
+        }
+    }
+}
+
 fn bench_fold_even_odd(c: &mut Criterion) {
     let log_sizes = [12, 14, 16, 18, 20, 22];
 
@@ -42,5 +95,23 @@ fn bench_fold_even_odd(c: &mut Criterion) {
     bench::<Complex<Mersenne31>>(c, &log_sizes);
 }
 
-criterion_group!(benches, bench_fold_even_odd);
+fn bench_yu_fold_poly(c: &mut Criterion) {
+    let log_sizes = [12, 14, 16, 18, 20, 22];
+    let folding_factors = [2, 4, 8, 16];
+
+    bench_yu::<BabyBear>(c, &log_sizes, &folding_factors);
+    bench_yu::<Goldilocks>(c, &log_sizes, &folding_factors);
+    bench_yu::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
+}
+
+fn bench_fold_poly_with_dft(c: &mut Criterion) {
+    let log_sizes = [12, 14, 16, 18, 20, 22];
+    let folding_factors = [2, 4, 8, 16];
+
+    bench_dft::<BabyBear>(c, &log_sizes, &folding_factors);
+    bench_dft::<Goldilocks>(c, &log_sizes, &folding_factors);
+    bench_dft::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
+}
+
+criterion_group!(benches, bench_fold_even_odd, bench_yu_fold_poly, bench_fold_poly_with_dft);
 criterion_main!(benches);

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -6,7 +6,6 @@ use p3_baby_bear::BabyBear;
 use p3_field::extension::Complex;
 use p3_field::TwoAdicField;
 use p3_fri::fold_even_odd;
-use p3_fri::yu_fold_poly;
 use p3_fri::fold_poly_with_dft;
 use p3_goldilocks::Goldilocks;
 use p3_mersenne_31::Mersenne31;
@@ -36,57 +35,6 @@ where
     }
 }
 
-fn bench_yu<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
-where
-    Standard: Distribution<F>,
-{
-    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
-    let mut group = c.benchmark_group(&name);
-    group.sample_size(10);
-
-    for log_size in log_sizes {
-        for folding_factor in folding_factors{
-            let n = 1 << log_size;
-
-            let mut rng = thread_rng();
-            let beta = rng.sample(Standard);
-            let poly = rng.sample_iter(Standard).take(n).collect_vec();
-    
-            group.bench_function(BenchmarkId::from_parameter(n), |b| {
-                b.iter(|| {
-                    yu_fold_poly(poly.clone(), beta, *folding_factor);
-                })
-            });
-        }
-    }
-}
-
-
-fn bench_dft<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
-where
-    Standard: Distribution<F>,
-{
-    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
-    let mut group = c.benchmark_group(&name);
-    group.sample_size(10);
-
-    for log_size in log_sizes {
-        for folding_factor in folding_factors{
-            let n = 1 << log_size;
-
-            let mut rng = thread_rng();
-            let beta = rng.sample(Standard);
-            let poly = rng.sample_iter(Standard).take(n).collect_vec();
-    
-            group.bench_function(BenchmarkId::from_parameter(n), |b| {
-                b.iter(|| {
-                    fold_poly_with_dft(poly.clone(), beta, *folding_factor);
-                })
-            });
-        }
-    }
-}
-
 fn bench_fold_even_odd(c: &mut Criterion) {
     let log_sizes = [12, 14, 16, 18, 20, 22];
 
@@ -95,23 +43,5 @@ fn bench_fold_even_odd(c: &mut Criterion) {
     bench::<Complex<Mersenne31>>(c, &log_sizes);
 }
 
-fn bench_yu_fold_poly(c: &mut Criterion) {
-    let log_sizes = [12, 14, 16, 18, 20, 22];
-    let folding_factors = [2, 4, 8, 16];
-
-    bench_yu::<BabyBear>(c, &log_sizes, &folding_factors);
-    bench_yu::<Goldilocks>(c, &log_sizes, &folding_factors);
-    bench_yu::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
-}
-
-fn bench_fold_poly_with_dft(c: &mut Criterion) {
-    let log_sizes = [12, 14, 16, 18, 20, 22];
-    let folding_factors = [2, 4, 8, 16];
-
-    bench_dft::<BabyBear>(c, &log_sizes, &folding_factors);
-    bench_dft::<Goldilocks>(c, &log_sizes, &folding_factors);
-    bench_dft::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
-}
-
-criterion_group!(benches, bench_fold_even_odd, bench_yu_fold_poly, bench_fold_poly_with_dft);
+criterion_group!(benches, bench_fold_even_odd);
 criterion_main!(benches);

--- a/fri/benches/fold_poly_with_dft.rs
+++ b/fri/benches/fold_poly_with_dft.rs
@@ -1,0 +1,50 @@
+use std::any::type_name;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use itertools::Itertools;
+use p3_baby_bear::BabyBear;
+use p3_field::extension::Complex;
+use p3_field::TwoAdicField;
+use p3_fri::fold_poly_with_dft;
+use p3_goldilocks::Goldilocks;
+use p3_mersenne_31::Mersenne31;
+use rand::distributions::{Distribution, Standard};
+use rand::{thread_rng, Rng};
+
+fn bench_dft<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
+where
+    Standard: Distribution<F>,
+{
+    let name = format!("fold_poly_with_dft::<{}>", type_name::<F>(),);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+
+    for log_size in log_sizes {
+        for folding_factor in folding_factors{
+            let n = 1 << log_size;
+
+            let mut rng = thread_rng();
+            let beta = rng.sample(Standard);
+            let poly = rng.sample_iter(Standard).take(n).collect_vec();
+
+            let benchmark_id: String = format!("n: {}, folding_factor: {}", n, folding_factor);
+            group.bench_function(BenchmarkId::new(&benchmark_id, n), |b| {
+                b.iter(|| {
+                    fold_poly_with_dft(poly.clone(), beta, *folding_factor);
+                })
+            });
+        }
+    }
+}
+
+fn bench_fold_poly_with_dft(c: &mut Criterion) {
+    let log_sizes = [12, 14, 16, 18, 20, 22];
+    let folding_factors = [2, 4, 8, 16];
+
+    bench_dft::<BabyBear>(c, &log_sizes, &folding_factors);
+    bench_dft::<Goldilocks>(c, &log_sizes, &folding_factors);
+    bench_dft::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
+}
+
+criterion_group!(benches, bench_fold_poly_with_dft);
+criterion_main!(benches);

--- a/fri/benches/yu_fold_poly.rs
+++ b/fri/benches/yu_fold_poly.rs
@@ -1,0 +1,50 @@
+use std::any::type_name;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use itertools::Itertools;
+use p3_baby_bear::BabyBear;
+use p3_field::extension::Complex;
+use p3_field::TwoAdicField;
+use p3_fri::yu_fold_poly;
+use p3_goldilocks::Goldilocks;
+use p3_mersenne_31::Mersenne31;
+use rand::distributions::{Distribution, Standard};
+use rand::{thread_rng, Rng};
+
+fn bench_yu<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize], folding_factors: &[usize])
+where
+    Standard: Distribution<F>,
+{
+    let name = format!("yu_fold_poly::<{}>", type_name::<F>(),);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+
+    for log_size in log_sizes {
+        for folding_factor in folding_factors {
+            let n = 1 << log_size;
+
+            let mut rng = thread_rng();
+            let beta = rng.sample(Standard);
+            let poly = rng.sample_iter(Standard).take(n).collect_vec();
+
+            let benchmark_id: String = format!("n: {}, folding_factor: {}", n, folding_factor);
+            group.bench_function(BenchmarkId::new(&benchmark_id, n), |b| {
+                b.iter(|| {
+                    yu_fold_poly(poly.clone(), beta, *folding_factor);
+                })
+            });
+        }
+    }
+}
+
+fn bench_yu_fold_poly(c: &mut Criterion) {
+    let log_sizes = [12, 14, 16, 18, 20, 22];
+    let folding_factors = [2, 4, 8, 16];
+
+    bench_yu::<BabyBear>(c, &log_sizes, &folding_factors);
+    bench_yu::<Goldilocks>(c, &log_sizes, &folding_factors);
+    bench_yu::<Complex<Mersenne31>>(c, &log_sizes, &folding_factors);
+}
+
+criterion_group!(benches, bench_yu_fold_poly);
+criterion_main!(benches);

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -55,6 +55,7 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: Vec<F>, beta: F) -> Vec<F> {
 }
 
 pub fn fold_poly<F: TwoAdicField,M: Matrix<F>>(poly: Vec<F>, beta: F, folding_factor: usize) -> Vec<F> {
+    assert!(folding_factor > 0 && (folding_factor & (folding_factor - 1)) == 0, "The folding factor must be a power of 2");
     assert!(poly.len() % folding_factor == 0, "The length of the poly must be divisible by the folding factor");
 
     // let mut xs = F::two_adic_generator(log2_strict_usize(poly.len())).powers().take(poly.len()).collect::<Vec<F>>();
@@ -85,6 +86,8 @@ pub fn fold_poly_matrix<F: TwoAdicField,M: Matrix<F>>(poly: M, beta: F, folding_
 }
 
 pub fn yu_fold_poly<F: TwoAdicField>(poly: Vec<F>, beta: F, folding_factor: usize) -> Vec<F> {
+    assert!(folding_factor > 0 && (folding_factor & (folding_factor - 1)) == 0, "The folding factor must be a power of 2");
+    assert!(poly.len() % folding_factor == 0, "The length of the poly must be divisible by the folding factor");
     let log_folding_factor  = log2_ceil_usize(folding_factor);
     
     let mut folded_poly = poly;
@@ -98,6 +101,7 @@ pub fn yu_fold_poly<F: TwoAdicField>(poly: Vec<F>, beta: F, folding_factor: usiz
 }
 
 pub fn fold_poly_with_dft<F: TwoAdicField>(poly: Vec<F>, beta: F, folding_factor: usize) -> Vec<F> {
+    assert!(folding_factor > 0 && (folding_factor & (folding_factor - 1)) == 0, "The folding factor must be a power of 2");
     assert!(poly.len() % folding_factor == 0, "The length of the poly must be divisible by the folding factor");
 
     let m = RowMajorMatrix::new(poly, folding_factor);
@@ -330,7 +334,7 @@ mod tests {
         let p_0_coeffs = coeffs.iter().cloned().step_by(folding_factor).collect_vec();
         let new_degree  = p_0_coeffs.len();
         let p_0_evals = dft.dft(p_0_coeffs);
-        
+
         let p_1_coeffs = coeffs.iter().cloned().skip(1).step_by(folding_factor).collect_vec();
         let p_1_evals = dft.dft(p_1_coeffs);
 


### PR DESCRIPTION
# cargo bench --bench fold_even_odd  
``` Bash
cargo bench --bench fold_even_odd     
warning: unused import: `p3_interpolation::interpolate_coset`
  --> fri/src/fold_even_odd.rs:11:5
   |
11 | use p3_interpolation::interpolate_coset;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `fold_poly` and `yu_fold_poly`
  --> fri/src/two_adic_pcs.rs:25:28
   |
25 | use crate::fold_even_odd::{yu_fold_poly,multi_fold_row,fold_poly};
   |                            ^^^^^^^^^^^^                ^^^^^^^^^

warning: unused import: `alloc::vec`
 --> fri/src/verifier.rs:3:5
  |
3 | use alloc::vec;
  |     ^^^^^^^^^^

warning: unused import: `serde::de::Error`
  --> fri/src/lib.rs:19:5
   |
19 | use serde::de::Error;
   |     ^^^^^^^^^^^^^^^^

warning: unused imports: `Itertools` and `izip`
  --> fri/src/lib.rs:21:17
   |
21 | use itertools::{izip, Itertools};
   |                 ^^^^  ^^^^^^^^^

warning: unused import: `p3_matrix::dense::RowMajorMatrix`
  --> fri/src/lib.rs:25:5
   |
25 | use p3_matrix::dense::RowMajorMatrix;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `p3_util::log2_strict_usize`
  --> fri/src/lib.rs:26:5
   |
26 | use p3_util::log2_strict_usize;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `info_span` and `instrument`
  --> fri/src/lib.rs:27:15
   |
27 | use tracing::{info_span, instrument};
   |               ^^^^^^^^^  ^^^^^^^^^^

warning: `p3-fri` (lib) generated 8 warnings (run `cargo fix --lib -p p3-fri` to apply 8 suggestions)
warning: unused import: `p3_fri::fold_poly_with_dft`
 --> fri/benches/fold_even_odd.rs:9:5
  |
9 | use p3_fri::fold_poly_with_dft;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `p3-fri` (bench "fold_even_odd") generated 1 warning (run `cargo fix --bench "fold_even_odd"` to apply 1 suggestion)
    Finished `bench` profile [optimized] target(s) in 0.27s
     Running benches/fold_even_odd.rs (target/release/deps/fold_even_odd-7e1922604ec4dfbb)
Gnuplot not found, using plotters backend
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/40...
                        time:   [14.823 µs 14.981 µs 15.376 µs]
                        change: [-8.1592% -0.5634% +7.0650%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/16...
                        time:   [59.199 µs 59.728 µs 60.586 µs]
                        change: [-0.5207% +1.8374% +5.5385%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/65...
                        time:   [246.08 µs 262.87 µs 293.28 µs]
                        change: [-6.0688% +1.5631% +10.990%] (p = 0.77 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/26...
                        time:   [1.2255 ms 1.2319 ms 1.2410 ms]
                        change: [-3.1310% -0.7737% +1.2351%] (p = 0.56 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/10...
                        time:   [5.7410 ms 5.7707 ms 5.7925 ms]
                        change: [-5.3766% -3.8707% -2.3906%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_even_odd::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>/41...
                        time:   [23.234 ms 23.446 ms 23.665 ms]
                        change: [-5.0332% -2.3557% -0.1109%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

fold_even_odd::<p3_goldilocks::Goldilocks>/4096
                        time:   [14.519 µs 14.535 µs 14.562 µs]
                        change: [-4.5323% -2.2054% -0.7355%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_even_odd::<p3_goldilocks::Goldilocks>/16384
                        time:   [65.707 µs 65.920 µs 66.289 µs]
                        change: [-1.0222% +0.9270% +3.1671%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_even_odd::<p3_goldilocks::Goldilocks>/65536
                        time:   [263.67 µs 269.28 µs 275.19 µs]
                        change: [-2.9270% -0.3246% +2.2074%] (p = 0.81 > 0.05)
                        No change in performance detected.
fold_even_odd::<p3_goldilocks::Goldilocks>/262144
                        time:   [1.3767 ms 1.4083 ms 1.4262 ms]
                        change: [-4.8368% -2.5924% -0.5605%] (p = 0.03 < 0.05)
                        Change within noise threshold.
fold_even_odd::<p3_goldilocks::Goldilocks>/1048576
                        time:   [6.3770 ms 6.4908 ms 6.6785 ms]
                        change: [-0.5849% +1.8640% +4.6490%] (p = 0.22 > 0.05)
                        No change in performance detected.
fold_even_odd::<p3_goldilocks::Goldilocks>/4194304
                        time:   [27.474 ms 29.113 ms 31.617 ms]
                        change: [-0.3196% +4.6825% +13.553%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers...
                        time:   [33.076 µs 33.728 µs 35.754 µs]
                        change: [-0.2512% +9.1675% +24.281%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #2: Collecting 10 samples in estimated 5.0066 s (35k iterations
fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #2
                        time:   [142.57 µs 142.99 µs 143.27 µs]
                        change: [-1.5498% -0.3176% +0.7634%] (p = 0.63 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high mild
Benchmarking fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #3: Collecting 10 samples in estimated 5.0067 s (8745 iteration
fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #3
                        time:   [577.43 µs 590.47 µs 609.21 µs]
                        change: [-0.5774% +1.1419% +3.0816%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #4: Collecting 10 samples in estimated 5.1215 s (1705 iteration
fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #4
                        time:   [2.6385 ms 2.6691 ms 2.7009 ms]
                        change: [-3.4674% -0.7770% +1.9470%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #5: Collecting 10 samples in estimated 5.2141 s (440 iterations
fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #5
                        time:   [11.735 ms 11.900 ms 12.066 ms]
                        change: [-2.1637% -0.7165% +0.6866%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #6: Collecting 10 samples in estimated 5.2743 s (110 iterations
fold_even_odd::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31::mers... #6
                        time:   [47.150 ms 48.353 ms 50.928 ms]
                        change: [-1.8452% +5.5780% +17.627%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```

# cargo bench --bench yu_fold_poly 

```bash
(base) harold@BanZhuan-8 Plonky3 % cargo bench --bench fold_poly_with_dft
warning: unused import: `p3_interpolation::interpolate_coset`
  --> fri/src/fold_even_odd.rs:11:5
   |
11 | use p3_interpolation::interpolate_coset;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `fold_poly` and `yu_fold_poly`
  --> fri/src/two_adic_pcs.rs:25:28
   |
25 | use crate::fold_even_odd::{yu_fold_poly,multi_fold_row,fold_poly};
   |                            ^^^^^^^^^^^^                ^^^^^^^^^

warning: unused import: `alloc::vec`
 --> fri/src/verifier.rs:3:5
  |
3 | use alloc::vec;
  |     ^^^^^^^^^^

warning: unused import: `serde::de::Error`
  --> fri/src/lib.rs:19:5
   |
19 | use serde::de::Error;
   |     ^^^^^^^^^^^^^^^^

warning: unused imports: `Itertools` and `izip`
  --> fri/src/lib.rs:21:17
   |
21 | use itertools::{izip, Itertools};
   |                 ^^^^  ^^^^^^^^^

warning: unused import: `p3_matrix::dense::RowMajorMatrix`
  --> fri/src/lib.rs:25:5
   |
25 | use p3_matrix::dense::RowMajorMatrix;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `p3_util::log2_strict_usize`
  --> fri/src/lib.rs:26:5
   |
26 | use p3_util::log2_strict_usize;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `info_span` and `instrument`
  --> fri/src/lib.rs:27:15
   |
27 | use tracing::{info_span, instrument};
   |               ^^^^^^^^^  ^^^^^^^^^^

warning: `p3-fri` (lib) generated 8 warnings (run `cargo fix --lib -p p3-fri` to apply 8 suggestions)
    Finished `bench` profile [optimized] target(s) in 0.32s
     Running benches/fold_poly_with_dft.rs (target/release/deps/fold_poly_with_dft-d07a2e677e392015)
Gnuplot not found, using plotters backend
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters...
                        time:   [429.89 µs 430.86 µs 431.78 µs]
                        change: [-4.1447% -2.7127% -1.6200%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #2: Collecting 10 samples in estimated 5.0108 s (21k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #2
                        time:   [240.57 µs 240.93 µs 241.65 µs]
                        change: [-1.8670% -1.4754% -1.1027%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #3: Collecting 10 samples in estimated 5.0001 s (32k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #3
                        time:   [150.42 µs 150.81 µs 151.14 µs]
                        change: [-1.3821% -0.8212% -0.3168%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #4: Collecting 10 samples in estimated 5.0018 s (44k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #4
                        time:   [112.45 µs 113.51 µs 115.37 µs]
                        change: [-0.8671% -0.2115% +0.7989%] (p = 0.71 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #5: Collecting 10 samples in estimated 5.0506 s (2915 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #5
                        time:   [1.7256 ms 1.7437 ms 1.7693 ms]
                        change: [-0.5001% +0.5794% +1.6397%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #6: Collecting 10 samples in estimated 5.0290 s (5005 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #6
                        time:   [965.76 µs 976.45 µs 992.60 µs]
                        change: [-0.0676% +3.2596% +6.8357%] (p = 0.10 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #7: Collecting 10 samples in estimated 5.0294 s (8360 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #7
                        time:   [594.27 µs 595.00 µs 596.25 µs]
                        change: [-1.7650% -1.2780% -0.7978%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #8: Collecting 10 samples in estimated 5.0037 s (11k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #8
                        time:   [449.59 µs 453.76 µs 457.93 µs]
                        change: [+1.7784% +2.4730% +3.1762%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #9: Collecting 10 samples in estimated 5.3530 s (770 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #9
                        time:   [6.9309 ms 7.0012 ms 7.1348 ms]
                        change: [+1.4476% +3.0403% +4.9879%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #10: Collecting 10 samples in estimated 5.1417 s (1320 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #10
                        time:   [3.8526 ms 3.8866 ms 3.9429 ms]
                        change: [-4.6617% -0.5754% +2.8848%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #11: Collecting 10 samples in estimated 5.0653 s (2090 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #11
                        time:   [2.3948 ms 2.4270 ms 2.4798 ms]
                        change: [+0.8063% +1.7995% +3.0204%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #12: Collecting 10 samples in estimated 5.0295 s (2805 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #12
                        time:   [1.7966 ms 1.8457 ms 1.9103 ms]
                        change: [+1.1583% +3.2811% +6.0836%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #13: Collecting 10 samples in estimated 6.2287 s (220 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #13
                        time:   [27.840 ms 28.053 ms 28.377 ms]
                        change: [+0.3098% +2.1885% +5.2167%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #14: Collecting 10 samples in estimated 5.1034 s (330 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #14
                        time:   [15.455 ms 15.496 ms 15.527 ms]
                        change: [+0.5187% +0.9373% +1.3660%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #15: Collecting 10 samples in estimated 5.3279 s (550 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #15
                        time:   [9.6360 ms 9.7307 ms 9.9382 ms]
                        change: [+1.3601% +2.5866% +4.5984%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #16: Collecting 10 samples in estimated 5.1301 s (715 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #16
                        time:   [7.1993 ms 7.3470 ms 7.5669 ms]
                        change: [+0.5255% +2.1173% +4.1631%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.3s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17: Collecting 10 samples in estimated 6.3041 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17
                        time:   [114.45 ms 115.00 ms 115.92 ms]
                        change: [-0.3131% +1.4806% +3.2573%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #18: Collecting 10 samples in estimated 6.9708 s (110 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #18
                        time:   [63.130 ms 64.739 ms 66.479 ms]
                        change: [+1.8671% +3.6058% +5.7619%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #19: Collecting 10 samples in estimated 6.4949 s (165 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #19
                        time:   [39.287 ms 40.582 ms 43.377 ms]
                        change: [+1.1097% +4.0538% +8.7598%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #20: Collecting 10 samples in estimated 6.4385 s (220 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #20
                        time:   [29.189 ms 29.241 ms 29.330 ms]
                        change: [-5.6004% -1.4015% +1.9350%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #21: Collecting 10 samples in estimated 9.3545 s (20 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #21
                        time:   [452.86 ms 456.32 ms 459.83 ms]
                        change: [+1.3818% +2.2182% +3.0335%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #22: Collecting 10 samples in estimated 5.0632 s (20 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #22
                        time:   [250.75 ms 252.12 ms 253.53 ms]
                        change: [+1.0983% +1.6925% +2.3733%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.7s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23: Collecting 10 samples in estimated 8.6575 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23
                        time:   [156.77 ms 158.82 ms 161.85 ms]
                        change: [+2.3141% +3.7084% +5.3546%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.5s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24: Collecting 10 samples in estimated 6.4736 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24
                        time:   [114.61 ms 114.92 ms 115.53 ms]
                        change: [-2.3921% +0.4752% +2.3101%] (p = 0.79 > 0.05)
                        No change in performance detected.

fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 2/4096
                        time:   [588.93 µs 589.66 µs 590.82 µs]
                        change: [+0.5645% +1.3042% +2.0203%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 4/4096
                        time:   [329.89 µs 331.84 µs 336.48 µs]
                        change: [+0.0315% +1.8892% +4.5287%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 8/4096
                        time:   [192.80 µs 193.84 µs 195.34 µs]
                        change: [+0.5031% +1.0780% +1.7479%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 16/4096
                        time:   [137.27 µs 138.63 µs 141.41 µs]
                        change: [+1.0265% +2.5768% +4.3640%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 2/16384
                        time:   [2.4202 ms 2.4663 ms 2.5198 ms]
                        change: [-5.8758% +0.2671% +4.6917%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 4/16384
                        time:   [1.3658 ms 1.4209 ms 1.5000 ms]
                        change: [-0.8329% +3.8027% +10.161%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 8/16384
                        time:   [768.17 µs 770.86 µs 775.58 µs]
                        change: [-14.082% -4.8748% +1.1634%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 16/16384
                        time:   [548.51 µs 569.09 µs 585.60 µs]
                        change: [-0.7444% +1.7620% +4.6892%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 2/65536
                        time:   [9.5482 ms 9.5696 ms 9.6041 ms]
                        change: [+1.8436% +2.3596% +2.8137%] (p = 0.00 < 0.05)
                        Performance has regressed.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 4/65536
                        time:   [5.3294 ms 5.3360 ms 5.3461 ms]
                        change: [+1.4339% +2.0533% +2.5767%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 8/65536
                        time:   [3.1251 ms 3.1923 ms 3.2477 ms]
                        change: [+1.9765% +3.2174% +4.8897%] (p = 0.00 < 0.05)
                        Performance has regressed.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 16/65536
                        time:   [2.1754 ms 2.1809 ms 2.1859 ms]
                        change: [-1.2754% -0.3276% +0.9214%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 2/262144
                        time:   [38.749 ms 39.413 ms 40.125 ms]
                        change: [+2.0984% +3.1277% +4.4004%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 4/262144
                        time:   [21.500 ms 21.776 ms 21.957 ms]
                        change: [+1.1502% +2.3547% +3.7150%] (p = 0.00 < 0.05)
                        Performance has regressed.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 8/262144
                        time:   [12.591 ms 12.645 ms 12.702 ms]
                        change: [+0.6984% +1.4304% +2.2351%] (p = 0.00 < 0.05)
                        Change within noise threshold.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 16/262144
                        time:   [9.0307 ms 9.0439 ms 9.0643 ms]
                        change: [-3.1876% -0.1182% +2.1204%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 2/1048576: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.7s or enable flat sampling.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 2/1048576
                        time:   [155.05 ms 156.05 ms 158.59 ms]
                        change: [+2.3364% +6.5704% +12.633%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 4/1048576
                        time:   [86.307 ms 86.575 ms 86.917 ms]
                        change: [-2.3529% -0.8733% +0.4006%] (p = 0.29 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 8/1048576
                        time:   [50.561 ms 50.960 ms 52.022 ms]
                        change: [+1.8545% +3.5014% +5.7479%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 16/1048576
                        time:   [35.766 ms 35.824 ms 35.912 ms]
                        change: [+0.4073% +1.2077% +1.9025%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 2/4194304: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.2s.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 2/4194304
                        time:   [621.15 ms 628.46 ms 639.27 ms]
                        change: [-4.3006% -2.1526% +0.2820%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 4/4194304
                        time:   [344.64 ms 346.84 ms 349.50 ms]
                        change: [-4.7314% -4.0075% -3.2324%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 8/4194304
                        time:   [204.36 ms 205.16 ms 205.86 ms]
                        change: [+1.5388% +2.1074% +2.6219%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 16/4194304: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.0s or enable flat sampling.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 16/4194304
                        time:   [143.94 ms 149.55 ms 157.54 ms]
                        change: [+0.8515% +3.1537% +6.1681%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:...
                        time:   [397.60 µs 407.86 µs 419.02 µs]
                        change: [+2.2518% +4.7983% +8.0611%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #2: Collecting 10 samples in estimated 5.0071 s (19k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #2
                        time:   [253.28 µs 255.98 µs 258.23 µs]
                        change: [+0.5056% +1.4645% +2.4393%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #3: Collecting 10 samples in estimated 5.0048 s (25k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #3
                        time:   [196.94 µs 197.67 µs 198.30 µs]
                        change: [-1.1663% +0.3599% +1.5868%] (p = 0.67 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #4: Collecting 10 samples in estimated 5.0022 s (26k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #4
                        time:   [190.83 µs 191.27 µs 191.80 µs]
                        change: [+0.7637% +1.1647% +1.5782%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #5: Collecting 10 samples in estimated 5.0769 s (3190 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #5
                        time:   [1.5786 ms 1.6450 ms 1.6911 ms]
                        change: [+1.8774% +3.7667% +5.7699%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #6: Collecting 10 samples in estimated 5.0091 s (4895 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #6
                        time:   [1.0157 ms 1.0180 ms 1.0199 ms]
                        change: [+0.5391% +1.2095% +1.9063%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #7: Collecting 10 samples in estimated 5.0052 s (6325 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #7
                        time:   [788.27 µs 801.96 µs 829.78 µs]
                        change: [+0.1775% +2.3036% +5.2151%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #8: Collecting 10 samples in estimated 5.0086 s (6490 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #8
                        time:   [772.65 µs 779.24 µs 788.78 µs]
                        change: [+1.3029% +2.3950% +3.5858%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #9: Collecting 10 samples in estimated 5.2375 s (825 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #9
                        time:   [6.3043 ms 6.3663 ms 6.4639 ms]
                        change: [+1.7751% +2.7815% +3.9607%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #10: Collecting 10 samples in estimated 5.2146 s (1265 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #10
                        time:   [4.0797 ms 4.1573 ms 4.2595 ms]
                        change: [+0.0393% +1.9290% +3.7059%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #11: Collecting 10 samples in estimated 5.0206 s (1540 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #11
                        time:   [3.1555 ms 3.1674 ms 3.1906 ms]
                        change: [+1.0316% +2.1234% +3.6110%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #12: Collecting 10 samples in estimated 5.0287 s (1650 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #12
                        time:   [3.0361 ms 3.0514 ms 3.0844 ms]
                        change: [+0.5871% +1.2588% +2.0409%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #13: Collecting 10 samples in estimated 5.7095 s (220 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #13
                        time:   [25.655 ms 25.814 ms 26.098 ms]
                        change: [+1.2223% +3.6916% +7.2690%] (p = 0.02 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #14: Collecting 10 samples in estimated 5.6100 s (330 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #14
                        time:   [16.711 ms 16.743 ms 16.807 ms]
                        change: [-3.2262% -0.9643% +1.0748%] (p = 0.44 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #15: Collecting 10 samples in estimated 5.7139 s (440 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #15
                        time:   [12.770 ms 12.812 ms 12.883 ms]
                        change: [+0.2065% +0.8961% +1.7355%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #16: Collecting 10 samples in estimated 5.5106 s (440 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #16
                        time:   [12.318 ms 12.360 ms 12.453 ms]
                        change: [+0.6206% +1.2585% +1.8973%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.0s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17: Collecting 10 samples in estimated 5.9748 s (55 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17
                        time:   [106.21 ms 107.97 ms 111.64 ms]
                        change: [+4.2111% +7.3189% +10.725%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #18: Collecting 10 samples in estimated 7.4021 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #18
                        time:   [66.493 ms 66.772 ms 67.079 ms]
                        change: [+0.4568% +1.0907% +1.6347%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #19: Collecting 10 samples in estimated 5.7101 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #19
                        time:   [51.288 ms 51.534 ms 51.836 ms]
                        change: [+0.6095% +1.3273% +1.9916%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #20: Collecting 10 samples in estimated 5.7437 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #20
                        time:   [49.447 ms 49.653 ms 50.102 ms]
                        change: [+1.0338% +3.0889% +5.7722%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #21: Collecting 10 samples in estimated 8.6140 s (20 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #21
                        time:   [419.04 ms 421.21 ms 423.58 ms]
                        change: [-0.5667% +0.2394% +1.0730%] (p = 0.59 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #22: Collecting 10 samples in estimated 5.4600 s (20 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #22
                        time:   [271.32 ms 273.15 ms 275.09 ms]
                        change: [+2.5473% +3.4310% +4.2416%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #23: Collecting 10 samples in estimated 6.4390 s (30 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #23
                        time:   [207.67 ms 209.79 ms 212.65 ms]
                        change: [-1.8387% +0.3355% +2.4903%] (p = 0.78 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #24: Collecting 10 samples in estimated 6.0342 s (30 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #24
                        time:   [198.63 ms 200.62 ms 203.45 ms]
                        change: [+1.2883% +2.3047% +3.6402%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

```

# cargo bench --bench fold_poly_with_dft 

```bash
warning: unused import: `p3_interpolation::interpolate_coset`
  --> fri/src/fold_even_odd.rs:11:5
   |
11 | use p3_interpolation::interpolate_coset;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `fold_poly` and `yu_fold_poly`
  --> fri/src/two_adic_pcs.rs:25:28
   |
25 | use crate::fold_even_odd::{yu_fold_poly,multi_fold_row,fold_poly};
   |                            ^^^^^^^^^^^^                ^^^^^^^^^

warning: unused import: `alloc::vec`
 --> fri/src/verifier.rs:3:5
  |
3 | use alloc::vec;
  |     ^^^^^^^^^^

warning: unused import: `serde::de::Error`
  --> fri/src/lib.rs:19:5
   |
19 | use serde::de::Error;
   |     ^^^^^^^^^^^^^^^^

warning: unused imports: `Itertools` and `izip`
  --> fri/src/lib.rs:21:17
   |
21 | use itertools::{izip, Itertools};
   |                 ^^^^  ^^^^^^^^^

warning: unused import: `p3_matrix::dense::RowMajorMatrix`
  --> fri/src/lib.rs:25:5
   |
25 | use p3_matrix::dense::RowMajorMatrix;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `p3_util::log2_strict_usize`
  --> fri/src/lib.rs:26:5
   |
26 | use p3_util::log2_strict_usize;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `info_span` and `instrument`
  --> fri/src/lib.rs:27:15
   |
27 | use tracing::{info_span, instrument};
   |               ^^^^^^^^^  ^^^^^^^^^^

warning: `p3-fri` (lib) generated 8 warnings (run `cargo fix --lib -p p3-fri` to apply 8 suggestions)
    Finished `bench` profile [optimized] target(s) in 0.30s
     Running benches/fold_poly_with_dft.rs (target/release/deps/fold_poly_with_dft-d07a2e677e392015)
Gnuplot not found, using plotters backend
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters...
                        time:   [429.25 µs 436.12 µs 448.38 µs]
                        change: [-0.3482% +1.1541% +2.9241%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #2: Collecting 10 samples in estimated 5.0117 s (20k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #2
                        time:   [240.52 µs 241.03 µs 241.52 µs]
                        change: [-0.3648% +0.9499% +3.2713%] (p = 0.58 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #3: Collecting 10 samples in estimated 5.0022 s (33k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #3
                        time:   [149.14 µs 150.65 µs 152.59 µs]
                        change: [-0.8650% -0.2044% +0.7007%] (p = 0.62 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #4: Collecting 10 samples in estimated 5.0008 s (42k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #4
                        time:   [112.17 µs 113.81 µs 116.44 µs]
                        change: [-1.4718% -0.0625% +1.5883%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #5: Collecting 10 samples in estimated 5.0096 s (2915 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #5
                        time:   [1.7120 ms 1.7209 ms 1.7337 ms]
                        change: [-1.7409% -0.7233% +0.1205%] (p = 0.17 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #6: Collecting 10 samples in estimated 5.0502 s (5280 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #6
                        time:   [953.04 µs 954.07 µs 956.34 µs]
                        change: [-7.1579% -4.3831% -1.9370%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #7: Collecting 10 samples in estimated 5.0022 s (8415 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #7
                        time:   [595.08 µs 599.62 µs 610.86 µs]
                        change: [+0.0349% +1.5428% +3.8036%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #8: Collecting 10 samples in estimated 5.0204 s (11k iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #8
                        time:   [454.08 µs 463.36 µs 471.02 µs]
                        change: [-0.0740% +1.6027% +3.4327%] (p = 0.12 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #9: Collecting 10 samples in estimated 5.1252 s (715 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #9
                        time:   [6.9069 ms 6.9623 ms 7.0842 ms]
                        change: [-3.3461% -0.9093% +1.2922%] (p = 0.53 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #10: Collecting 10 samples in estimated 5.1351 s (1320 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #10
                        time:   [3.8837 ms 3.9079 ms 3.9304 ms]
                        change: [-2.2337% -0.1543% +1.3895%] (p = 0.90 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #11: Collecting 10 samples in estimated 5.1213 s (2090 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #11
                        time:   [2.4177 ms 2.4231 ms 2.4301 ms]
                        change: [-0.8557% +0.4608% +1.4892%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #12: Collecting 10 samples in estimated 5.0139 s (2750 iteratio
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #12
                        time:   [1.7953 ms 1.8011 ms 1.8062 ms]
                        change: [-3.9260% -1.2856% +0.7654%] (p = 0.41 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #13: Collecting 10 samples in estimated 6.1859 s (220 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #13
                        time:   [28.204 ms 28.309 ms 28.411 ms]
                        change: [-2.8116% -0.1977% +1.5427%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #14: Collecting 10 samples in estimated 5.2079 s (330 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #14
                        time:   [15.752 ms 16.049 ms 16.539 ms]
                        change: [+1.0904% +3.0457% +5.4420%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #15: Collecting 10 samples in estimated 5.3190 s (550 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #15
                        time:   [9.5846 ms 9.6040 ms 9.6294 ms]
                        change: [-2.9322% -1.2433% -0.1225%] (p = 0.12 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #16: Collecting 10 samples in estimated 5.1663 s (715 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #16
                        time:   [7.2440 ms 7.3179 ms 7.4063 ms]
                        change: [-1.8823% +0.1363% +1.7889%] (p = 0.90 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.2s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17: Collecting 10 samples in estimated 6.2498 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #17
                        time:   [113.38 ms 115.80 ms 119.88 ms]
                        change: [-1.1156% +2.8336% +8.9241%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #18: Collecting 10 samples in estimated 6.8691 s (110 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #18
                        time:   [62.470 ms 62.737 ms 63.322 ms]
                        change: [-3.3973% -1.1664% +0.7620%] (p = 0.35 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #19: Collecting 10 samples in estimated 6.4215 s (165 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #19
                        time:   [39.395 ms 41.142 ms 42.764 ms]
                        change: [-5.4859% -0.1269% +4.4673%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #20: Collecting 10 samples in estimated 5.2150 s (165 iteration
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #20
                        time:   [29.323 ms 29.937 ms 31.036 ms]
                        change: [-0.4941% +1.0993% +3.4744%] (p = 0.42 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #21: Collecting 10 samples in estimated 9.1307 s (20 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #21
                        time:   [452.19 ms 453.78 ms 455.13 ms]
                        change: [-1.3777% -0.5573% +0.2686%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low severe
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #22: Collecting 10 samples in estimated 5.0463 s (20 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #22
                        time:   [251.90 ms 252.74 ms 253.66 ms]
                        change: [-0.4089% +0.2470% +0.8907%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23: Collecting 10 samples in estimated 8.6249 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #23
                        time:   [155.36 ms 157.21 ms 160.98 ms]
                        change: [-2.8085% -0.4377% +1.9253%] (p = 0.75 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.3s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24: Collecting 10 samples in estimated 6.3178 s (55 iterations
fold_poly_with_dft::<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters... #24
                        time:   [115.03 ms 119.40 ms 127.09 ms]
                        change: [+0.0377% +4.2076% +9.3708%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 2/4096
                        time:   [585.99 µs 587.55 µs 589.03 µs]
                        change: [-0.9356% -0.4058% +0.0728%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 4/4096
                        time:   [331.22 µs 332.02 µs 332.80 µs]
                        change: [-2.3655% -0.1834% +1.1478%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 8/4096
                        time:   [196.18 µs 196.80 µs 197.39 µs]
                        change: [+0.9487% +1.5980% +2.1774%] (p = 0.00 < 0.05)
                        Change within noise threshold.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4096, folding_factor: 16/4096
                        time:   [136.73 µs 137.61 µs 138.25 µs]
                        change: [-3.3232% -1.6948% -0.3234%] (p = 0.04 < 0.05)
                        Change within noise threshold.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 2/16384
                        time:   [2.3420 ms 2.3598 ms 2.3835 ms]
                        change: [-4.9899% -3.3534% -1.9166%] (p = 0.00 < 0.05)
                        Performance has improved.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 4/16384
                        time:   [1.3332 ms 1.3697 ms 1.4031 ms]
                        change: [-7.9340% -3.1423% +1.0680%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 8/16384
                        time:   [774.80 µs 777.41 µs 780.17 µs]
                        change: [-0.4364% +0.6347% +1.4207%] (p = 0.24 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 16384, folding_factor: 16/16384
                        time:   [548.22 µs 550.34 µs 552.21 µs]
                        change: [-4.3054% -1.9377% +0.0660%] (p = 0.12 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 2/65536
                        time:   [9.4860 ms 9.5462 ms 9.6088 ms]
                        change: [-0.9516% -0.4051% +0.1905%] (p = 0.20 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 4/65536
                        time:   [5.2898 ms 5.3368 ms 5.3853 ms]
                        change: [-1.1360% -0.5868% +0.0861%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 8/65536
                        time:   [3.2413 ms 3.7417 ms 4.2624 ms]
                        change: [+9.9509% +28.252% +55.146%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 65536, folding_factor: 16/65536
                        time:   [2.1530 ms 2.1663 ms 2.1799 ms]
                        change: [-2.2321% +1.5939% +8.0059%] (p = 0.75 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 2/262144
                        time:   [37.917 ms 38.306 ms 38.637 ms]
                        change: [-3.6379% -2.2791% -0.9612%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 4/262144
                        time:   [21.682 ms 21.912 ms 22.303 ms]
                        change: [-0.4650% +2.4132% +6.2359%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 8/262144
                        time:   [12.612 ms 12.719 ms 12.872 ms]
                        change: [-0.4142% +1.5004% +3.6817%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 262144, folding_factor: 16/262144
                        time:   [8.8737 ms 8.9059 ms 8.9287 ms]
                        change: [-2.7880% -2.1453% -1.5923%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 2/1048576: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.5s or enable flat sampling.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 2/1048576
                        time:   [154.07 ms 155.84 ms 158.78 ms]
                        change: [-8.8169% -3.6989% +0.5275%] (p = 0.19 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 4/1048576
                        time:   [85.723 ms 86.039 ms 86.356 ms]
                        change: [-0.7676% -0.3921% -0.0147%] (p = 0.07 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 8/1048576
                        time:   [50.092 ms 50.387 ms 50.780 ms]
                        change: [-3.7479% -1.6995% -0.2704%] (p = 0.08 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 1048576, folding_factor: 16/1048576
                        time:   [35.538 ms 35.645 ms 35.745 ms]
                        change: [-1.2942% -0.6549% -0.1064%] (p = 0.05 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 2/4194304: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.3s.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 2/4194304
                        time:   [619.84 ms 623.44 ms 626.75 ms]
                        change: [-2.5673% -0.7981% +0.5297%] (p = 0.42 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 4/4194304
                        time:   [348.32 ms 349.89 ms 351.35 ms]
                        change: [+0.0051% +0.8792% +1.6661%] (p = 0.07 > 0.05)
                        No change in performance detected.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 8/4194304
                        time:   [202.61 ms 205.94 ms 210.47 ms]
                        change: [-1.3319% +0.3809% +2.4847%] (p = 0.76 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 16/4194304: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.0s or enable flat sampling.
fold_poly_with_dft::<p3_goldilocks::Goldilocks>/n: 4194304, folding_factor: 16/4194304
                        time:   [144.10 ms 146.55 ms 150.64 ms]
                        change: [-3.4104% -0.0392% +2.8595%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:...
                        time:   [400.63 µs 415.88 µs 436.77 µs]
                        change: [-1.0938% +4.3681% +9.9722%] (p = 0.15 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #2: Collecting 10 samples in estimated 5.0086 s (19k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #2
                        time:   [254.04 µs 255.62 µs 258.29 µs]
                        change: [-0.1611% +1.1476% +2.6712%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #3: Collecting 10 samples in estimated 5.0027 s (25k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #3
                        time:   [199.39 µs 200.55 µs 203.23 µs]
                        change: [+0.9675% +4.0082% +7.8550%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #4: Collecting 10 samples in estimated 5.0001 s (26k iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #4
                        time:   [190.78 µs 191.23 µs 191.85 µs]
                        change: [-0.2821% +0.3145% +0.9631%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #5: Collecting 10 samples in estimated 5.0295 s (3135 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #5
                        time:   [1.5665 ms 1.5933 ms 1.6571 ms]
                        change: [-3.1085% +0.1310% +4.3785%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #6: Collecting 10 samples in estimated 5.0533 s (5005 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #6
                        time:   [1.0067 ms 1.0187 ms 1.0278 ms]
                        change: [-1.2614% -0.5570% +0.2136%] (p = 0.19 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #7: Collecting 10 samples in estimated 5.0048 s (6325 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #7
                        time:   [778.17 µs 781.52 µs 785.76 µs]
                        change: [-5.5234% -2.9741% -0.8755%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #8: Collecting 10 samples in estimated 5.0293 s (6600 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #8
                        time:   [758.78 µs 760.86 µs 766.40 µs]
                        change: [-2.6768% +0.2528% +4.7076%] (p = 0.92 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #9: Collecting 10 samples in estimated 5.2525 s (825 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #9
                        time:   [6.3770 ms 6.4251 ms 6.4614 ms]
                        change: [-0.4242% +0.8510% +2.1930%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #10: Collecting 10 samples in estimated 5.0068 s (1210 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #10
                        time:   [4.0443 ms 4.0695 ms 4.1020 ms]
                        change: [-2.4294% +0.0445% +3.9844%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #11: Collecting 10 samples in estimated 5.1777 s (1595 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #11
                        time:   [3.1676 ms 3.1777 ms 3.1950 ms]
                        change: [-1.7180% -0.4447% +0.5843%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #12: Collecting 10 samples in estimated 5.0426 s (1650 iteratio
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #12
                        time:   [3.0423 ms 3.0669 ms 3.0968 ms]
                        change: [-0.3601% +0.5830% +1.5819%] (p = 0.28 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #13: Collecting 10 samples in estimated 5.6569 s (220 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #13
                        time:   [25.509 ms 25.966 ms 26.584 ms]
                        change: [-5.1014% -1.8537% +0.7079%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #14: Collecting 10 samples in estimated 5.4506 s (330 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #14
                        time:   [16.529 ms 16.659 ms 16.744 ms]
                        change: [-2.2092% -1.5133% -0.7966%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #15: Collecting 10 samples in estimated 5.6686 s (165 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #15
                        time:   [13.151 ms 13.725 ms 15.155 ms]
                        change: [+9.4623% +30.651% +58.519%] (p = 0.02 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #16: Collecting 10 samples in estimated 5.5611 s (440 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #16
                        time:   [12.357 ms 12.392 ms 12.443 ms]
                        change: [-0.7820% -0.0940% +0.5971%] (p = 0.81 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.9s or enable flat sampling.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17: Collecting 10 samples in estimated 5.9156 s (55 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #17
                        time:   [106.30 ms 106.51 ms 106.68 ms]
                        change: [-6.0044% -2.9817% -0.2588%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #18: Collecting 10 samples in estimated 7.3215 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #18
                        time:   [66.137 ms 66.478 ms 66.735 ms]
                        change: [-0.7831% -0.3228% +0.1095%] (p = 0.21 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #19: Collecting 10 samples in estimated 5.6247 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #19
                        time:   [50.989 ms 51.284 ms 51.597 ms]
                        change: [-1.2302% -0.4828% +0.4151%] (p = 0.31 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #20: Collecting 10 samples in estimated 5.5676 s (110 iteration
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #20
                        time:   [49.573 ms 49.821 ms 50.206 ms]
                        change: [-3.6783% +1.0518% +7.4603%] (p = 0.80 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #21: Collecting 10 samples in estimated 8.5748 s (20 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #21
                        time:   [424.79 ms 427.32 ms 430.09 ms]
                        change: [+0.6637% +1.4482% +2.3157%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #22: Collecting 10 samples in estimated 5.3212 s (20 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #22
                        time:   [266.38 ms 267.98 ms 269.66 ms]
                        change: [-2.7882% -1.8931% -0.9914%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #23: Collecting 10 samples in estimated 6.2776 s (30 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #23
                        time:   [206.46 ms 207.32 ms 208.21 ms]
                        change: [-2.5693% -1.1777% -0.0321%] (p = 0.10 > 0.05)
                        No change in performance detected.
Benchmarking fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #24: Collecting 10 samples in estimated 5.9597 s (30 iterations
fold_poly_with_dft::<p3_field::extension::binomial_extension::BinomialExtensionField<p3_mersenne_31:... #24
                        time:   [197.94 ms 198.54 ms 199.21 ms]
                        change: [-2.4337% -1.0333% +0.0128%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```
